### PR TITLE
🐛fix fresh repo clone errors caused by empty drops directory

### DIFF
--- a/server.js
+++ b/server.js
@@ -92,7 +92,7 @@ function nameMap(file) {
 
 app.get('/drops', async (req, res) => {
     const files = await fs.readdir('./drops')
-    const json = files.filter((name) => { name.endsWith('ogg') }).map(nameMap)
+    const json = files.filter((name) => { return name.endsWith('ogg') }).map(nameMap)
 
     res.send(json)
 

--- a/server.js
+++ b/server.js
@@ -92,8 +92,7 @@ function nameMap(file) {
 
 app.get('/drops', async (req, res) => {
     const files = await fs.readdir('./drops')
-
-    const json = files.map(nameMap)
+    const json = files.filter((name) => { name.endsWith('ogg') }).map(nameMap)
 
     res.send(json)
 


### PR DESCRIPTION
This PR adds the empty `drops` directory, allowing a fresh clone to run first-time.

## Intent

The drops directory is ignored in `.gitignore`, but running the server with a fresh clone produces an error:

```
Listening on http://localhost:3000
node:internal/process/promises:246
          triggerUncaughtException(err, true /* fromPromise */);
          ^

[Error: ENOENT: no such file or directory, scandir ./drops] {
  errno: -2,
  code: ENOENT,
  syscall: scandir,
  path: ./drops
}
[nodemon] app crashed - waiting for file changes before starting...
```

We could add a note to the readme, or just create an empty directory by default, ignoring all other changes to it. This PR implements the latter.

## Consequences

To add the empty directory to git, it needs to hold something. I've added an empty `.keep` file to achieve this, though there's probably a newer, cooler naming scheme I don't know of yet.

I've filtered the drops file list to only include files ending in `ogg`. We could opt to just filter out `.`-prefixed files, or ignore `.keep` explicitly.