### PR TITLE
🐛 Fixes the mic select list not initialising on page load

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -212,7 +212,10 @@
                     if (localStorage.device) {
                         this.device = localStorage.getItem('device');
                     }
-
+                    // we need to wait for getUserMedia to get mic permission from the user
+                    // before we can enumerateDevices (or anything else)
+                    await navigator.mediaDevices.getUserMedia({ audio: true, video: false })
+                    
                     devices = await navigator.mediaDevices.enumerateDevices()
 
                     this.devices = devices.filter(device=>device.kind==='audioinput');


### PR DESCRIPTION
Fixes "Input device selection isn't available until microphone access has been granted, which isn't available until the first time the Drop button is clicked" in #1.

`navigator.mediaDevices.enumerateDevices()` doesn't prompt the user for permission to access the mic, so I think we need to just wait for `getUserMedia`, even though we don't do anything with its return value.

This PR gives us the mic permission pop-up on page load:

https://user-images.githubusercontent.com/464482/121644045-70b2dd80-ca8a-11eb-8dce-37d44166ffa5.mov

