### PR TITLE
✨ Feedback when input selection is saved

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -63,8 +63,10 @@
                         {{device.label}}
                     </option>
                 </select>
+                <notification ref="successNotification">Selection saved</notification>
             </div>
         </template>
+
         <template id="app-login">
             <div v-if="submitted" class=" is-flex is-justify-content-flex-end is-align-items-center">
                 <p>
@@ -105,6 +107,12 @@
             </div>
         </template>
 
+        <template id="notification">
+            <div class="notification is-success" v-if="!hidden">
+                <button class="delete" @click="hide"></button>
+                <slot></slot>
+            </div>
+        </template>
         <script src="./dropper.js"></script>
         <script>            
             Vue.component('drop-adder', {
@@ -216,11 +224,11 @@
                     devices = await navigator.mediaDevices.enumerateDevices()
 
                     this.devices = devices.filter(device=>device.kind==='audioinput');
-
                 },
                 watch: {
                     device(dev) {
                         localStorage.setItem('device', dev);
+                        this.$refs.successNotification.show()
                     }
                 },
                 template: '#input-select'
@@ -326,6 +334,23 @@
                 },
 
                 template: '#sound-player'
+            })
+
+            Vue.component('notification', {
+                template: '#notification',
+                data: () => { 
+                    return {
+                        hidden: true
+                    } 
+                },
+                
+                methods: {
+                    show() { 
+                        this.hidden = false
+                        setTimeout(this.hide, 2000)
+                    },
+                    hide() { this.hidden = true }
+                }
             })
 
             new Vue({ el: '#app' });

--- a/static/index.html
+++ b/static/index.html
@@ -214,13 +214,9 @@
                 data: () => ({
                     
                     devices: [],
-                    device: ''
+                    device: localStorage.getItem('device')
                 }),
                 async mounted() {
-                    if (localStorage.device) {
-                        this.device = localStorage.getItem('device');
-                    }
-
                     devices = await navigator.mediaDevices.enumerateDevices()
 
                     this.devices = devices.filter(device=>device.kind==='audioinput');


### PR DESCRIPTION
This PR

- adds a `notification` component to wrap the Bulma notification component.
- automatically clears the notification after 2 seconds.
- shifts the point we load the mic preference from localstorage into `data`, which prevents it from triggering a change event on the selected device (this popped up a notification on page load).

This resolves "No feedback that the input device change has been saved to local session" in #1.


https://user-images.githubusercontent.com/464482/121657003-effade00-ca97-11eb-980e-fbffd3a21952.mov

