### PR TITLE
✨ Improve drop length display & recording date/time

### DIFF
--- a/server.js
+++ b/server.js
@@ -84,7 +84,7 @@ app.get('/duration/:file', (req, res) => {
 function nameMap(file) {
     return ({
         path: file,
-        date: (new Date(file.split('-')[0]*1)).toLocaleDateString(),
+        date: new Date(file.split('-')[0]*1),
         name: file.split('-')[1].split('.')[0]
         // 
     })

--- a/static/index.html
+++ b/static/index.html
@@ -99,7 +99,7 @@
 
         <template id="sound-player">
             <div class="is-flex is-flex-direction-row">
-                <span class="is-flex-grow-1"><strong>{{ drop.name }}</strong> {{drop.date}} ({{duration | timecode}}) </span>
+                <span class="is-flex-grow-1"><strong>{{ drop.name }}</strong> {{dropDate}} at {{dropTime}} ({{duration | timecode}}) </span>
                 <button v-on:click="play" v-if="!isPlaying" class="button is-dark is-align-self-flex-end">Play</button>
                 <button v-on:click="stop" v-if="isPlaying" class="button is-dark is-align-self-flex-end">Stop</button> 
             </div>
@@ -305,8 +305,9 @@
                     const player = this.player =  new Howl({
                         src: [`/drops/${vm.drop.path}`]
                     });
-                    
-                    this.date = vm.drop.path.split('-')[0];
+
+                    // this.date = vm.drop.path.split('-')[0];
+
                     this.player.on('load', function(){
                         vm.duration = player.duration();
                     });
@@ -333,6 +334,21 @@
                     },
                     stop () {
                         this.player.stop()
+                    }
+                },
+
+                computed: {
+                    
+                    dropDate() {
+                        return new Date(this.drop.date).toLocaleDateString()
+                    },
+
+                    dropTime() {
+                        const dropDate = new Date(this.drop.date)
+                        
+                        // we pass undefined as the locale to let us pass options without overriding the host locale
+                        const hours = dropDate.getHours().toLocaleString(undefined, { minimumIntegerDigits: 2 })
+                        return `${hours}:${dropDate.getMinutes()}`
                     }
                 },
 

--- a/static/index.html
+++ b/static/index.html
@@ -99,7 +99,7 @@
 
         <template id="sound-player">
             <div class="is-flex is-flex-direction-row">
-                <span class="is-flex-grow-1"><strong>{{ drop.name }}</strong> {{dropDate}} at {{dropTime}} ({{duration}}) </span>
+                <span class="is-flex-grow-1"><strong>{{ drop.name }}</strong> {{dropDate}} at {{dropTime}} ({{dropTimecode}}) </span>
                 <button v-on:click="play" v-if="!isPlaying" class="button is-dark is-align-self-flex-end">Play</button>
                 <button v-on:click="stop" v-if="isPlaying" class="button is-dark is-align-self-flex-end">Stop</button> 
             </div>
@@ -339,6 +339,15 @@
                         // we pass undefined as the locale to let us pass options without overriding the host locale
                         const hours = dropDate.getHours().toLocaleString(undefined, { minimumIntegerDigits: 2 })
                         return `${hours}:${dropDate.getMinutes()}`
+                    },
+
+                    dropTimecode() {
+                        var seconds = Math.floor(this.duration % 60).toString();
+                        var minutes = Math.floor(this.duration / 60).toString();
+                        if (seconds.length === 1) {
+                            seconds = '0' + seconds;
+                        }
+                        return minutes + ':' + seconds;
                     }
                 },
 

--- a/static/index.html
+++ b/static/index.html
@@ -99,24 +99,14 @@
 
         <template id="sound-player">
             <div class="is-flex is-flex-direction-row">
-                <span class="is-flex-grow-1"><strong>{{ drop.name }}</strong> {{dropDate}} at {{dropTime}} ({{duration | timecode}}) </span>
+                <span class="is-flex-grow-1"><strong>{{ drop.name }}</strong> {{dropDate}} at {{dropTime}} ({{duration}}) </span>
                 <button v-on:click="play" v-if="!isPlaying" class="button is-dark is-align-self-flex-end">Play</button>
                 <button v-on:click="stop" v-if="isPlaying" class="button is-dark is-align-self-flex-end">Stop</button> 
             </div>
         </template>
 
         <script src="./dropper.js"></script>
-        <script>
-            // Credit: https://gist.github.com/diverted247/1b8335579f1fa31ed6e2
-            Vue.filter('timecode', function (value) {
-                    var seconds = Math.floor(value % 60).toString();
-                    var minutes = Math.floor(value / 60).toString();
-                    if (seconds.length === 1) {
-                        seconds = '0' + seconds;
-                    }
-                    return minutes + ':' + seconds;
-                });
-
+        <script>            
             Vue.component('drop-adder', {
                 data: () => ({
                     isRecording: false,

--- a/static/index.html
+++ b/static/index.html
@@ -99,14 +99,24 @@
 
         <template id="sound-player">
             <div class="is-flex is-flex-direction-row">
-                <span class="is-flex-grow-1"><strong>{{ drop.name }}</strong> {{drop.date}} ({{duration}}) </span>
+                <span class="is-flex-grow-1"><strong>{{ drop.name }}</strong> {{drop.date}} ({{duration | timecode}}) </span>
                 <button v-on:click="play" v-if="!isPlaying" class="button is-dark is-align-self-flex-end">Play</button>
                 <button v-on:click="stop" v-if="isPlaying" class="button is-dark is-align-self-flex-end">Stop</button> 
             </div>
         </template>
 
         <script src="./dropper.js"></script>
-        <script>            
+        <script>
+            // Credit: https://gist.github.com/diverted247/1b8335579f1fa31ed6e2
+            Vue.filter('timecode', function (value) {
+                    var seconds = Math.floor(value % 60).toString();
+                    var minutes = Math.floor(value / 60).toString();
+                    if (seconds.length === 1) {
+                        seconds = '0' + seconds;
+                    }
+                    return minutes + ':' + seconds;
+                });
+
             Vue.component('drop-adder', {
                 data: () => ({
                     isRecording: false,

--- a/static/index.html
+++ b/static/index.html
@@ -305,11 +305,12 @@
                     const player = this.player =  new Howl({
                         src: [`/drops/${vm.drop.path}`]
                     });
-
+                    
                     this.date = vm.drop.path.split('-')[0];
-
-                    this.player.on('play', function(){
+                    this.player.on('load', function(){
                         vm.duration = player.duration();
+                    });
+                    this.player.on('play', function(){
                         vm.isPlaying = true
                     });  
                     this.player.on('stop', function(){


### PR DESCRIPTION
This PR

- formats the drop length with minutes & seconds
- grabs the drop length when the media is loaded rather than on play
- adds the recording timestamp
- shifts the date/time formatting to the Vue component so we can use browser localisation

<img width="385" alt="Screenshot 2021-06-11 at 10 59 37" src="https://user-images.githubusercontent.com/464482/121669345-20e11000-caa4-11eb-84e7-72d92669c2f8.png">

This should resolve the following from #1:

- Recording lengths not presented until played
- Recording lengths not presented in a sensible format
- Recording date doesn't show time

There's a momentary blip before the drop lengths are displayed because Howler needs to load the media. We could add some  logic to show the drop only once it's been loaded.


https://user-images.githubusercontent.com/464482/121669247-0870f580-caa4-11eb-9a7d-7a1e1968e344.mov

